### PR TITLE
Chore: Bump version to 1.1.9 and initialize ProGuard rules

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -52,7 +52,7 @@ android {
         applicationId = "com.thejawnpaul.gptinvestor"
         minSdk = 24
         targetSdk = 36
-        versionCode = 30
+        versionCode = 31
         versionName = "1.1.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -52,8 +52,8 @@ android {
         applicationId = "com.thejawnpaul.gptinvestor"
         minSdk = 24
         targetSdk = 36
-        versionCode = 29
-        versionName = "1.1.8"
+        versionCode = 30
+        versionName = "1.1.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Custom ProGuard/R8 rules for the Android app module.
+# Keep this file even if empty so the release build can enable minification.
+


### PR DESCRIPTION
This commit increments the application versioning and adds a placeholder ProGuard/R8 configuration file to the Android module.

- **Build & Configuration:**
    - Updated `versionCode` to `30` and `versionName` to `1.1.9` in `androidApp/build.gradle.kts`.
    - Created `androidApp/proguard-rules.pro` to support custom minification rules for release builds.