### PR TITLE
Feat: Implement suggested prompt click handling in HistoryViewModel

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/history/presentation/viewmodel/HistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/history/presentation/viewmodel/HistoryViewModel.kt
@@ -254,6 +254,7 @@ class HistoryViewModel(
     fun handleHistoryDetailEvent(event: HistoryDetailEvent) {
         when (event) {
             is HistoryDetailEvent.ClickSuggestedPrompt -> {
+                getSuggestedPromptResponse(query = event.prompt)
             }
 
             is HistoryDetailEvent.GetHistory -> {
@@ -370,6 +371,23 @@ class HistoryViewModel(
                     HistoryDetailAction.ShowToast("Billing Error: ${result.message}")
                 )
             }
+        }
+    }
+
+    private fun getSuggestedPromptResponse(query: String) {
+        conversationView.update {
+            it.copy(loading = true)
+        }
+        getInputPromptUseCase(
+            ConversationPrompt(
+                conversationId = conversationId ?: -1L,
+                query = query
+            )
+        ) {
+            it.fold(
+                ::handleInputResponseFailure,
+                ::handleInputResponseSuccess
+            )
         }
     }
 }


### PR DESCRIPTION
This PR adds the necessary logic to process suggested prompt clicks within the history detail screen, allowing users to trigger new query responses from suggested prompt

- **ViewModel Logic:**
    - Updated `handleHistoryDetailEvent` to invoke `getSuggestedPromptResponse` when a `ClickSuggestedPrompt` event is received.
    - Added a private `getSuggestedPromptResponse` function to manage the loading state and execute `getInputPromptUseCase` using the selected prompt and current conversation ID.