### PR TITLE
Implement Activity context tracking for Android authentication

### DIFF
--- a/androidApp/src/main/kotlin/com/thejawnpaul/gptinvestor/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/thejawnpaul/gptinvestor/MainActivity.kt
@@ -16,6 +16,7 @@ import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.UpdateAvailability
+import com.thejawnpaul.gptinvestor.core.platform.ActivityContextHolder
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         installSplashScreen()
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        ActivityContextHolder.set(this)
         appUpdateManager = AppUpdateManagerFactory.create(this)
         checkForUpdates()
 
@@ -95,6 +97,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        ActivityContextHolder.set(this)
         appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
             if (appUpdateInfo.updateAvailability() ==
                 UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
@@ -106,5 +109,10 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        ActivityContextHolder.clear()
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/thejawnpaul/gptinvestor/core/platform/ActivityContextHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/thejawnpaul/gptinvestor/core/platform/ActivityContextHolder.kt
@@ -1,0 +1,18 @@
+package com.thejawnpaul.gptinvestor.core.platform
+
+import android.app.Activity
+import java.lang.ref.WeakReference
+
+object ActivityContextHolder {
+    private var activityRef: WeakReference<Activity>? = null
+
+    fun set(activity: Activity) {
+        activityRef = WeakReference(activity)
+    }
+
+    fun clear() {
+        activityRef = null
+    }
+
+    fun get(): Activity? = activityRef?.get()
+}

--- a/composeApp/src/androidMain/kotlin/com/thejawnpaul/gptinvestor/features/authentication/domain/AuthenticationRepository.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/thejawnpaul/gptinvestor/features/authentication/domain/AuthenticationRepository.android.kt
@@ -8,6 +8,7 @@ import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential.Companion.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
 import com.thejawnpaul.gptinvestor.core.api.KtorApiService
+import com.thejawnpaul.gptinvestor.core.platform.ActivityContextHolder
 import com.thejawnpaul.gptinvestor.core.platform.AndroidPlatformContext
 import com.thejawnpaul.gptinvestor.core.platform.AppConfig
 import com.thejawnpaul.gptinvestor.core.platform.PlatformContext
@@ -33,10 +34,10 @@ actual suspend fun loginWithGooglePlatform(
     platformContext: PlatformContext,
     appConfig: AppConfig
 ): Result<Unit> = try {
-    val androidContext = (platformContext as? AndroidPlatformContext)?.context
+    val appContext = (platformContext as? AndroidPlatformContext)?.context
         ?: throw IllegalArgumentException("Invalid platform context")
 
-    val credentialManager = CredentialManager.create(androidContext)
+    val credentialManager = CredentialManager.create(appContext)
     val googleIdOption = GetSignInWithGoogleOption.Builder(
         serverClientId = appConfig.webClientId
     ).build()
@@ -45,7 +46,8 @@ actual suspend fun loginWithGooglePlatform(
         .addCredentialOption(googleIdOption)
         .build()
 
-    val result = credentialManager.getCredential(androidContext, request)
+    val activityContext = ActivityContextHolder.get() ?: appContext
+    val result = credentialManager.getCredential(activityContext, request)
     val credential = result.credential
 
     if (credential is CustomCredential && credential.type == TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {


### PR DESCRIPTION
- **Platform Core**
    - Introduce `ActivityContextHolder`, a utility object using `WeakReference` to safely store and retrieve the current `Activity` instance.
    - Update `MainActivity` to register itself with `ActivityContextHolder` during `onCreate` and `onResume`, and clear the reference in `onDestroy`.

- **Authentication**
    - Refactor `performGoogleAuth` in the Android implementation to prioritize the activity-level context from `ActivityContextHolder`.
    - Ensure `CredentialManager.getCredential` is invoked with an `Activity` context to correctly support UI-bound authentication flows, falling back to the application context if necessary.