### PR TITLE
Add remote data models and API endpoints for watchlist, daily digest etc

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/core/api/KtorApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/core/api/KtorApiService.kt
@@ -5,8 +5,17 @@ import com.thejawnpaul.gptinvestor.features.authentication.data.remote.LoginRequ
 import com.thejawnpaul.gptinvestor.features.authentication.data.remote.LoginResponse
 import com.thejawnpaul.gptinvestor.features.authentication.data.remote.SignUpRequest
 import com.thejawnpaul.gptinvestor.features.authentication.data.remote.SignUpResponse
+import com.thejawnpaul.gptinvestor.features.billing.data.remote.AppleVerifyRequest
 import com.thejawnpaul.gptinvestor.features.billing.data.remote.VerifyPurchaseRequest
 import com.thejawnpaul.gptinvestor.features.billing.data.remote.VerifyPurchaseResponse
+import com.thejawnpaul.gptinvestor.features.digest.data.remote.model.DigestResponse
+import com.thejawnpaul.gptinvestor.features.settings.data.remote.model.UpdateUserSettingsRequest
+import com.thejawnpaul.gptinvestor.features.settings.data.remote.model.UserSettingsResponse
+import com.thejawnpaul.gptinvestor.features.trial.data.remote.model.StartTrialResponse
+import com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model.AddWatchlistRequest
+import com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model.AddWatchlistResponse
+import com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model.RemoveWatchlistResponse
+import com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model.WatchlistResponse
 import com.thejawnpaul.gptinvestor.features.company.data.remote.model.CompanyBriefRemote
 import com.thejawnpaul.gptinvestor.features.company.data.remote.model.CompanyDetailRemoteRequest
 import com.thejawnpaul.gptinvestor.features.company.data.remote.model.CompanyDetailRemoteResponse
@@ -45,6 +54,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.preparePost
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
@@ -208,6 +218,39 @@ class KtorApiService(@Provided private val client: HttpClient) {
 
     suspend fun clearSearchHistory(): KtorResponse<ClearHistoryResponse> =
         client.delete("v1.1/search/history").toKtorResponse()
+
+    suspend fun getWatchlist(page: Int = 1, pageSize: Int = 20): KtorResponse<WatchlistResponse> =
+        client.get("v1/watchlist") {
+            parameter("page", page)
+            parameter("page_size", pageSize)
+        }.toKtorResponse()
+
+    suspend fun addToWatchlist(request: AddWatchlistRequest): KtorResponse<AddWatchlistResponse> =
+        client.post("v1/watchlist") {
+            setBody(request)
+        }.toKtorResponse()
+
+    suspend fun removeFromWatchlist(ticker: String): KtorResponse<RemoveWatchlistResponse> =
+        client.delete("v1/watchlist/$ticker").toKtorResponse()
+
+    suspend fun getDailyDigest(): KtorResponse<DigestResponse> =
+        client.get("v1/digest").toKtorResponse()
+
+    suspend fun startFreeTrial(): KtorResponse<StartTrialResponse> =
+        client.post("v1/trial/start").toKtorResponse()
+
+    suspend fun getUserSettings(): KtorResponse<UserSettingsResponse> =
+        client.get("v1/user/settings").toKtorResponse()
+
+    suspend fun updateUserSettings(request: UpdateUserSettingsRequest): KtorResponse<UserSettingsResponse> =
+        client.put("v1/user/settings") {
+            setBody(request)
+        }.toKtorResponse()
+
+    suspend fun verifyApplePurchase(request: AppleVerifyRequest): KtorResponse<VerifyPurchaseResponse> =
+        client.post("v1/apple/verify") {
+            setBody(request)
+        }.toKtorResponse()
 }
 
 class KtorResponse<T>(val isSuccessful: Boolean, val body: T?, val errorBody: String?, val code: Int)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/billing/data/remote/AppleVerifyRequest.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/billing/data/remote/AppleVerifyRequest.kt
@@ -1,0 +1,9 @@
+package com.thejawnpaul.gptinvestor.features.billing.data.remote
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppleVerifyRequest(
+    @SerialName("original_transaction_id") val originalTransactionId: String
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/digest/data/remote/model/DigestItemRemote.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/digest/data/remote/model/DigestItemRemote.kt
@@ -1,0 +1,15 @@
+package com.thejawnpaul.gptinvestor.features.digest.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DigestItemRemote(
+    @SerialName("ticker") val ticker: String,
+    @SerialName("company_name") val companyName: String,
+    @SerialName("sentiment_change") val sentimentChange: String,
+    @SerialName("locked") val locked: Boolean,
+    @SerialName("summary") val summary: String? = null,
+    @SerialName("key_event") val keyEvent: String? = null,
+    @SerialName("generated_at") val generatedAt: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/digest/data/remote/model/DigestResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/digest/data/remote/model/DigestResponse.kt
@@ -1,0 +1,11 @@
+package com.thejawnpaul.gptinvestor.features.digest.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DigestResponse(
+    @SerialName("digest_date") val digestDate: String?,
+    @SerialName("is_stale") val isStale: Boolean?= null,
+    @SerialName("items") val items: List<DigestItemRemote>? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/settings/data/remote/model/UpdateUserSettingsRequest.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/settings/data/remote/model/UpdateUserSettingsRequest.kt
@@ -1,0 +1,11 @@
+package com.thejawnpaul.gptinvestor.features.settings.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateUserSettingsRequest(
+    @SerialName("digest_delivery_hour") val digestDeliveryHour: Int? = null,
+    @SerialName("timezone_iana") val timezoneIana: String? = null,
+    @SerialName("utc_offset_minutes") val utcOffsetMinutes: Int? = null,
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/settings/data/remote/model/UserSettingsResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/settings/data/remote/model/UserSettingsResponse.kt
@@ -1,0 +1,14 @@
+package com.thejawnpaul.gptinvestor.features.settings.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserSettingsResponse(
+    @SerialName("digest_delivery_hour") val digestDeliveryHour: Int? = null,
+    @SerialName("digest_utc_hour") val digestUtcHour: Int? = null,
+    @SerialName("notif_digest_enabled") val notifDigestEnabled: Boolean? = null,
+    @SerialName("timezone_iana") val timezoneIana: String? = null,
+    @SerialName("updated_at") val updatedAt: String? = null,
+    @SerialName("utc_offset_minutes") val utcOffsetMinutes: Int? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/trial/data/remote/model/StartTrialResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/trial/data/remote/model/StartTrialResponse.kt
@@ -1,0 +1,11 @@
+package com.thejawnpaul.gptinvestor.features.trial.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StartTrialResponse(
+    @SerialName("plan") val plan: String? = null,
+    @SerialName("source") val source: String? = null,
+    @SerialName("trial_expires_at") val trialExpiresAt: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/AddWatchlistRequest.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/AddWatchlistRequest.kt
@@ -1,0 +1,9 @@
+package com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AddWatchlistRequest(
+    @SerialName("ticker") val ticker: String
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/AddWatchlistResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/AddWatchlistResponse.kt
@@ -1,0 +1,12 @@
+package com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AddWatchlistResponse(
+    @SerialName("ticker") val ticker: String? = null,
+    @SerialName("company_name") val companyName: String? = null,
+    @SerialName("date_added") val dateAdded: String? = null,
+    @SerialName("logo_url") val logoUrl: String? = null,
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/RemoveWatchlistResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/RemoveWatchlistResponse.kt
@@ -1,0 +1,9 @@
+package com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RemoveWatchlistResponse(
+    @SerialName("success") val success: Boolean? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/WatchlistItemRemote.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/WatchlistItemRemote.kt
@@ -1,0 +1,13 @@
+package com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WatchlistItemRemote(
+    @SerialName("ticker") val ticker: String,
+    @SerialName("company_name") val companyName: String,
+    @SerialName("date_added") val dateAdded: String,
+    @SerialName("locked") val locked: Boolean,
+    @SerialName("logo_url") val logoUrl: String
+)

--- a/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/WatchlistResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/thejawnpaul/gptinvestor/features/watchlist/data/remote/model/WatchlistResponse.kt
@@ -1,0 +1,14 @@
+package com.thejawnpaul.gptinvestor.features.watchlist.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WatchlistResponse(
+    @SerialName("items") val items: List<WatchlistItemRemote>,
+    @SerialName("page") val page: Int,
+    @SerialName("page_size") val pageSize: Int,
+    @SerialName("total_items") val totalItems: Int,
+    @SerialName("cap") val cap: Int,
+    @SerialName("plan") val plan: String
+)


### PR DESCRIPTION
Add remote data models and API endpoints for watchlist, daily digest, user settings, and billing

- **Watchlist Feature**
    - Create `AddWatchlistRequest`, `RemoveWatchlistResponse`, `WatchlistItemRemote`, and `WatchlistResponse` data classes for remote synchronization.
    - Implement `getWatchlist`, `addToWatchlist`, and `removeFromWatchlist` endpoints in `KtorApiService`.

- **Daily Digest**
    - Add `DigestItemRemote` and `DigestResponse` models to handle daily investment summaries and sentiment changes.
    - Add `getDailyDigest` endpoint to fetch the latest investment digests.

- **User Settings**
    - Implement `UpdateUserSettingsRequest` and `UserSettingsResponse` to manage digest delivery preferences and notification states.
    - Add `getUserSettings` and `updateUserSettings` (PUT) methods to `KtorApiService`.

- **Billing and Trial**
    - Add `AppleVerifyRequest` for processing iOS-specific transaction verification.
    - Implement `startFreeTrial` and `verifyApplePurchase` endpoints.
    - Define `StartTrialResponse` to track trial expiration and plan details.